### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-5.2 (unreleased)
+6.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.1 (2025-02-14)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ TESTS_REQUIRE = [
 
 setup(
     name='zope.ptresource',
-    version='5.2.dev0',
+    version='6.0.dev0',
     url='https://github.com/zopefoundation/zope.ptresource/',
     project_urls={
         'Issue Tracker': ('https://github.com/zopefoundation/'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -28,7 +27,7 @@ long_description = (read('README.rst') + '\n\n' + read('CHANGES.rst'))
 
 TESTS_REQUIRE = [
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
 ]
 
 setup(
@@ -62,9 +61,6 @@ setup(
     description='Page template resource plugin for zope.browserresource',
     long_description=long_description,
     license='ZPL-2.1',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     install_requires=[
         'setuptools',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
